### PR TITLE
small change to the predict api

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ print(clf2.predict(addresse))
 
 ```
 
-    [['1']]
-    [['1']]
+    [True]
+    [True]
 
 
 
@@ -94,5 +94,5 @@ print(clf1.predict(addresses))
 print(clf2.predict(addresses))
 ```
 
-    [['1'], ['1'], ['0'], ['0']]
-    [['1'], ['1'], ['0'], ['0']]
+    [True, True, False, False]
+    [True, True, False, False]

--- a/addr_detector/Fasttext_clf.py
+++ b/addr_detector/Fasttext_clf.py
@@ -11,25 +11,26 @@ from pyfasttext import FastText
 import pkg_resources
 
 
+def is_addr(fasttext_output):
+    return fasttext_output == ['1']
+
+
 class Fasttext_clf(BaseEstimator, ClassifierMixin):
     data_path = pkg_resources.resource_filename('addr_detector.model', 'ft_ad.ftz')
+
     def __init__(self, path=data_path):
         self.model = FastText(path)
-        self.default = '0'
 
     def fit(self, X, y):
         return self
 
     def predict(self, X):
-        results = []
         if isinstance(X, str):  #
-            res=self.model.predict_single(X)
-            results = results + [self.default if not res  else res]
+            res = self.model.predict_single(X)
+            return [is_addr(res)]
         elif isinstance(X, list):
-           # X=[(x) for x in X]
-            res = self.model.predict(X)
-            results = results + self.model.predict(X)
-        return results
+            # X=[(x) for x in X]
+            return list(map(is_addr, self.model.predict(X)))
 
     def predict_proba(self, X):
         results = []

--- a/addr_detector/Postal_clf.py
+++ b/addr_detector/Postal_clf.py
@@ -28,7 +28,7 @@ class Postal_clf(BaseEstimator, ClassifierMixin):
     def predict(self, X):
         results = []
         if isinstance(X, str):  #
-            results.append(self.is_addr(X))
+            return [self.is_addr(X)]
         elif isinstance(X, list):
             for elt in X:
                 if isinstance(elt, str):
@@ -37,8 +37,6 @@ class Postal_clf(BaseEstimator, ClassifierMixin):
         return results
 
     def is_addr(self, X):
-
-        prediction = '0'
         full_road = False
         exp_add = self.expander(X)
         parsed_add = self.parser(exp_add[0])
@@ -60,20 +58,17 @@ class Postal_clf(BaseEstimator, ClassifierMixin):
             # eq=1, means it's just dummy name (like street)
             full_road = True
         if num_elt_addr >= 4:
-            prediction = '1'
+            return True
 
         elif (address['house_number'] is not None and address['city'] is not None and full_road):
-            prediction = '1'
+            return True
         elif (address['house_number'] is not None and address['postcode'] is not None and full_road):
-            prediction = '1'
+            return True
         elif (address['house_number'] is not None and full_road):
-            prediction = '0'
+            return False
         elif ((address['postcode'] or address['city']) is not None and full_road):
-            prediction = '1'
-        else:
-            prediction = '0'
-
-        return [prediction]
+            return True
+        return False
 
     def score(self, X, y=None):
         return sum(self.predict(X))

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,4 @@ exclude = docs
 
 [aliases]
 # Define setup.py command aliases here
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,13 @@ setup_requirements = [
 'Cython',
 'tox==2.3',
 'coverage==4.1',
-'Sphinx==1.4'
+'Sphinx==1.4',
+'pytest-runner'
 ]
 
 test_requirements = [
     # TODO: put package test requirements here
+    'pytest==3.2.3'
 ]
 
 setup(

--- a/tests/test_addr_detector.py
+++ b/tests/test_addr_detector.py
@@ -3,20 +3,42 @@
 
 """Tests for `addr_detector` package."""
 
+import pytest
+from addr_detector.Fasttext_clf import Fasttext_clf
+from addr_detector.Postal_clf import Postal_clf
 
-import unittest
 
-from addr_detector import addr_detector
+@pytest.fixture
+def postal():
+    return Postal_clf()
 
 
-class TestAddr_detector(unittest.TestCase):
-    """Tests for `addr_detector` package."""
+@pytest.fixture
+def fasttext():
+    return Fasttext_clf()
 
-    def setUp(self):
-        """Set up test fixtures, if any."""
 
-    def tearDown(self):
-        """Tear down test fixtures, if any."""
+def test_good_addr_fasttext(fasttext):
+    assert fasttext.predict('7 rue spontini paris') == [True]
 
-    def test_000_something(self):
-        """Test something."""
+
+def test_bad_addr_fasttext(fasttext):
+    assert fasttext.predict('Comment se faire cuire un oeuf') == [False]
+
+
+def test_batch_fasttext(fasttext):
+    r = fasttext.predict(['7 rue spontini paris', 'Comment se faire cuire un oeuf'])
+    assert r == [True, False]
+
+
+def test_good_addr_postal(postal):
+    assert postal.predict('7 rue spontini paris') == [True]
+
+
+def test_bad_addr_postal(postal):
+    assert postal.predict('Comment se faire cuire un oeuf') == [False]
+
+
+def test_batch_postal(postal):
+    r = postal.predict(['7 rue spontini paris', 'Comment se faire cuire un oeuf'])
+    assert r == [True, False]


### PR DESCRIPTION
the predict api now returns an array of booleans with the address prediction

`Fasttext_clf().predict(['7 rue spontini paris', 'Comment se faire cuire un oeuf']) == [True, False]`

(same api for libpostal)

I'm not sure of the [fasttext's is addr](https://github.com/antoine-de/addr_detector/blob/1531243c6c0251ccdb9b73b2b1e4e4cca138cb34/addr_detector/Fasttext_clf.py#L15), tell me if you want it done another way.

Note: I changed the test framework to `pytest` as it is easier to use.
