### PR TITLE
migrate to the official fasttext python wrapper

### DIFF
--- a/addr_detector/Fasttext_clf.py
+++ b/addr_detector/Fasttext_clf.py
@@ -7,39 +7,43 @@ Created on Wed Oct 18 09:27:48 2017
 """
 
 from sklearn.base import BaseEstimator, ClassifierMixin
-from pyfasttext import FastText
+from fastText import load_model
 import pkg_resources
 
 
 def is_addr(fasttext_output):
-    return fasttext_output == ['1']
+    """
+    the fasttext model is:
+    '__label__1': an address
+    '__label__0': not an address
+    """
+    if fasttext_output:
+        return fasttext_output[0] == '__label__1'
+    return False
 
 
 class Fasttext_clf(BaseEstimator, ClassifierMixin):
     data_path = pkg_resources.resource_filename('addr_detector.model', 'ft_ad.ftz')
 
     def __init__(self, path=data_path):
-        self.model = FastText(path)
+        self.model = load_model(path)
 
     def fit(self, X, y):
         return self
 
     def predict(self, X):
-        if isinstance(X, str):  #
-            res = self.model.predict_single(X)
-            return [is_addr(res)]
-        elif isinstance(X, list):
-            # X=[(x) for x in X]
-            return list(map(is_addr, self.model.predict(X)))
+        r = self.model.predict(X)
+        if r:
+            return is_addr(r[0])
+        return False
 
     def predict_proba(self, X):
-        results = []
-        if isinstance(X, str):  #
-            results = results + [self.model.predict_proba_single(X)]
-        elif isinstance(X, list):
-            #X=[(x+'\n') for x in X]
-            results = results + self.model.predict_proba(X)
-        return results
+        r = self.model.predict(X)
+        if r and len(r) >= 2:
+            probas = r[1]
+            if probas:
+                return probas[0]
+        return False
 
 
 def score(self, X, y=None):

--- a/addr_detector/Postal_clf.py
+++ b/addr_detector/Postal_clf.py
@@ -26,15 +26,7 @@ class Postal_clf(BaseEstimator, ClassifierMixin):
         return self
 
     def predict(self, X):
-        results = []
-        if isinstance(X, str):  #
-            return [self.is_addr(X)]
-        elif isinstance(X, list):
-            for elt in X:
-                if isinstance(elt, str):
-                    results.append(self.is_addr(elt))
-
-        return results
+        return self.is_addr(X)
 
     def is_addr(self, X):
         full_road = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ scipy
 postal==1.0
 scikit_learn==0.19.0
 # Note: we fix the commit of fasttext on the last commit to have been tested, but this can  (and should) be updated
-git+git://github.com/facebookresearch/fastText.git@c5cb6b2d0e295e58cfa827e38d2e9b1e0cbe09e4#egg=fastText&subdirectory=python
+git+git://github.com/facebookresearch/fastText.git@c5cb6b2d0e295e58cfa827e38d2e9b1e0cbe09e4#egg=fastTextpy&subdirectory=python
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 Cython
 numpy
+scipy
 postal==1.0
 scikit_learn==0.19.0
-pyfasttext
+# Note: we fix the commit of fasttext on the last commit to have been tested, but this can  (and should) be updated
+git+git://github.com/facebookresearch/fastText.git@c5cb6b2d0e295e58cfa827e38d2e9b1e0cbe09e4#egg=fastText&subdirectory=python
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,4 +8,4 @@ coverage==4.1
 Sphinx==1.4.8
 cryptography==1.7
 PyYAML==3.11
-
+pytest-runner

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,14 @@ requirements = [
     # TODO: put package requirements here
     'Cython',
     'numpy',
+    'scipy',
     'postal==1.0',
     'scikit_learn==0.19',
-    'fasttext'
+    'fastTextpy==0.0.1'
+]
+
+depedencies = [
+    'git+https://github.com/facebookresearch/fastText/archive/c5cb6b2d0e295e58cfa827e38d2e9b1e0cbe09e4.zip#egg=fastText-0.0.1&subdirectory=python'
 ]
 
 setup_requirements = [
@@ -65,4 +70,5 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     setup_requires=setup_requirements,
+    dependency_links=depedencies
 )

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ requirements = [
     'numpy',
     'postal==1.0',
     'scikit_learn==0.19',
-    'pyfasttext'
-
+    'fasttext'
 ]
 
 setup_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@
 """The setup script."""
 
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+import subprocess
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -18,24 +20,19 @@ requirements = [
     'scipy',
     'postal==1.0',
     'scikit_learn==0.19',
-    'fastTextpy==0.0.1'
-]
-
-depedencies = [
-    'git+https://github.com/facebookresearch/fastText/archive/c5cb6b2d0e295e58cfa827e38d2e9b1e0cbe09e4.zip#egg=fastText-0.0.1&subdirectory=python'
 ]
 
 setup_requirements = [
     # TODO(rdoume): put setup requirements (distutils extensions, etc.) here
-'bumpversion==0.5',
-'wheel==0.29',
-'watchdog==0.8',
-'flake8==2.6',
-'Cython',
-'tox==2.3',
-'coverage==4.1',
-'Sphinx==1.4',
-'pytest-runner'
+    'bumpversion==0.5',
+    'wheel==0.29',
+    'watchdog==0.8',
+    'flake8==2.6',
+    'Cython',
+    'tox==2.3',
+    'coverage==4.1',
+    'Sphinx==1.4',
+    'pytest-runner'
 ]
 
 test_requirements = [
@@ -43,7 +40,23 @@ test_requirements = [
     'pytest==3.2.3'
 ]
 
+class CustomGitDependenciesInstallCommand(install):
+    """
+    setuptool does not seems to be able to install git dependencies (with dependency_links)
+    so we use a pip install by hand
+    """
+
+    def run(self):
+        c = ['pip',
+             'install',
+             'scipy', # numpy and scipy does not seems to be installed too
+             'numpy',
+             'git+git://github.com/facebookresearch/fastText.git@c5cb6b2d0e295e58cfa827e38d2e9b1e0cbe09e4#egg=fastTextpy&subdirectory=python']
+        subprocess.check_call(c)
+        install.run(self)
+
 setup(
+    cmdclass={'install': CustomGitDependenciesInstallCommand},
     name='addr_detector',
     version='0.1.0',
     description="Python address detector ",
@@ -69,6 +82,5 @@ setup(
     ],
     test_suite='tests',
     tests_require=test_requirements,
-    setup_requires=setup_requirements,
-    dependency_links=depedencies
+    setup_requires=setup_requirements
 )

--- a/tests/test_addr_detector.py
+++ b/tests/test_addr_detector.py
@@ -19,26 +19,16 @@ def fasttext():
 
 
 def test_good_addr_fasttext(fasttext):
-    assert fasttext.predict('7 rue spontini paris') == [True]
+    assert fasttext.predict('7 rue spontini paris')
 
 
 def test_bad_addr_fasttext(fasttext):
-    assert fasttext.predict('Comment se faire cuire un oeuf') == [False]
-
-
-def test_batch_fasttext(fasttext):
-    r = fasttext.predict(['7 rue spontini paris', 'Comment se faire cuire un oeuf'])
-    assert r == [True, False]
+    assert not fasttext.predict('Comment se faire cuire un oeuf')
 
 
 def test_good_addr_postal(postal):
-    assert postal.predict('7 rue spontini paris') == [True]
+    assert postal.predict('7 rue spontini paris')
 
 
 def test_bad_addr_postal(postal):
-    assert postal.predict('Comment se faire cuire un oeuf') == [False]
-
-
-def test_batch_postal(postal):
-    r = postal.predict(['7 rue spontini paris', 'Comment se faire cuire un oeuf'])
-    assert r == [True, False]
+    assert not postal.predict('Comment se faire cuire un oeuf')


### PR DESCRIPTION
Use of the newly released official python wrapper.

Since this wrapper to not support the batch predict and we don't use it, simplify the api by only supporting the predict on a uniq query.

Because of this change this is a breaking change and the major version number should be increased